### PR TITLE
Eventdate

### DIFF
--- a/app/[locale]/(app)/program/ProgramPage.tsx
+++ b/app/[locale]/(app)/program/ProgramPage.tsx
@@ -7,6 +7,8 @@ import Image from 'next/image';
 import { ImageType } from '@/sanity/lib/queries/image';
 import { DynamicImage } from '@/components/DynamicImage';
 import { useLocale, useTranslations } from 'next-intl';
+import EventDate from '@/components/event/EventDate';
+import { getFirstAndLastDate } from '@/utils/formatDates';
 
 type ProgramPageProps = {
   data: PROGRAMPAGE_QUERYResult;
@@ -58,7 +60,10 @@ export const ProgramPage = ({ data }: ProgramPageProps) => {
               </h2>
               {link.dates && link.dates.length > 0 && (
                 <span className="inline-block mt-2">
-                  Sett inn dato her {/*<DatesLabel dates={link.dates} showBorder={false} />*/}
+                  <EventDate
+                    startDate={getFirstAndLastDate(link.dates).startDate}
+                    endDate={getFirstAndLastDate(link.dates).endDate}
+                  />
                 </span>
               )}
             </Link>

--- a/app/[locale]/(event)/program/[slug]/EventPage.tsx
+++ b/app/[locale]/(event)/program/[slug]/EventPage.tsx
@@ -1,4 +1,5 @@
 import { ColumnItem, Columns } from '@/components/column-layout';
+import EventDate from '@/components/event/EventDate';
 import ImageEventPage from '@/components/event/ImageEventPage';
 import { RolesBlock } from '@/components/event/RolesBlock';
 import { TicketBlock } from '@/components/event/TicketBlock';
@@ -8,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { urlFor } from '@/sanity/lib/image';
 import { EVENT_QUERYResult } from '@/sanity/types/types';
+import { getFirstAndLastDate } from '@/utils/formatDates';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
 
@@ -41,7 +43,14 @@ export const EventPage = async ({ data }: EventPageProps) => {
                 {label.toUpperCase()}
               </Badge>
             ))}
-            {dates && <Badge variant={'outline'}>DATO</Badge>}
+            {dates && (
+              <Badge variant={'outline'}>
+                <EventDate
+                  startDate={getFirstAndLastDate(dates).startDate}
+                  endDate={getFirstAndLastDate(dates).endDate}
+                />
+              </Badge>
+            )}
             {genre?.title && <Badge variant={'outline'}>{genre.title.toUpperCase()}</Badge>}
             <Button>
               <Link href="#ticket-block" scroll={true}>

--- a/components/event/EventDate.tsx
+++ b/components/event/EventDate.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useFormatter } from 'next-intl';
+
+interface EventDateProps {
+  startDate: string | Date;
+  endDate?: string | Date;
+}
+
+export default function EventDate({ startDate, endDate }: EventDateProps) {
+  const format = useFormatter();
+
+  let formattedDate;
+
+  if (endDate) {
+    formattedDate = `${format.dateTime(new Date(startDate), {
+      day: '2-digit',
+      month: 'long',
+    })} - ${format.dateTime(new Date(endDate), {
+      day: '2-digit',
+      month: 'long',
+    })}`;
+  } else {
+    formattedDate = format.dateTime(new Date(startDate), {
+      weekday: 'long',
+      day: '2-digit',
+      month: 'long',
+    });
+  }
+
+  return <div>{formattedDate}</div>;
+}

--- a/components/event/Ticket.tsx
+++ b/components/event/Ticket.tsx
@@ -3,6 +3,7 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import Link from 'next/link';
+import EventDate from './EventDate';
 
 type TicketProps = {
   date: NonNullable<NonNullable<EVENT_QUERYResult>['dates']>[number] | null;
@@ -34,11 +35,7 @@ export const Ticket = ({ date, saleStartOption, saleStartDateTime }: TicketProps
   return (
     <div>
       <h3 className="uppercase">
-        {format.dateTime(new Date(date?.date || ''), {
-          weekday: 'long',
-          day: '2-digit',
-          month: 'long',
-        })}
+        <EventDate startDate={date?.date || ''} />
       </h3>
       <h4 className="uppercase">
         {format.dateTime(new Date(date?.date || ''), {

--- a/utils/formatDates.ts
+++ b/utils/formatDates.ts
@@ -1,0 +1,17 @@
+export const getFirstAndLastDate = (
+  dates: { date?: string }[],
+): { startDate: string; endDate?: string } => {
+  if (!dates.length) {
+    return { startDate: '' };
+  }
+
+  const startDate = dates[0].date ?? '';
+
+  if (dates.length === 1) {
+    return { startDate };
+  }
+
+  const endDate = dates[dates.length - 1].date ?? '';
+
+  return { startDate, endDate };
+};


### PR DESCRIPTION
OBS! [Denne](https://github.com/bekk/bruddet-v2/pull/19) PRen må merges inn i main først. Også må denne rebases.

Notion:
https://www.notion.so/bekks/6b19742d4dff4e659af2d0aab93275d9?v=57a38c17bed64858a5032ac40fe1e11d&p=1a76bd308541809b98eec0e0e543d5d4&pm=s

Har laget en komponent EventDate som returnerer dato av format:
* `Mandag 17. juli` dersom det kun er en startdato og
* `5. juli - 12. august` derfor det er start- og sluttdato

Har brukt disse på programsiden under forestillingsnavn og to steder inne på forestillingssider. Se bilder nedenfor:

![Skjermbilde 2025-02-28 kl  14 58 39](https://github.com/user-attachments/assets/b618f528-6b63-48ab-9c19-047640050e0e)
![Skjermbilde 2025-02-28 kl  14 58 31](https://github.com/user-attachments/assets/72eefc54-c948-4727-aa9f-d9189a427f2d)
![Skjermbilde 2025-02-28 kl  14 58 35](https://github.com/user-attachments/assets/69cb8192-6d4e-414f-b295-8b52ce856331)
