### PR TITLE
Footer bugs etter testefest

### DIFF
--- a/components/footer/DesktopMiddleFooter.tsx
+++ b/components/footer/DesktopMiddleFooter.tsx
@@ -25,7 +25,7 @@ export default function DesktopMiddleFooter({
           href="#ticket-block"
           className="hidden md:w-[70%] md:flex justify-center items-center border-x border-foreground hover:bg-primary hover:text-primary-foreground hover:underline"
         >
-          <span className="font-bold uppercase">{t_event('buy-ticket')}</span>
+          <span className="font-bold uppercase text-xl">{t_event('buy-ticket')}</span>
         </Link>
       ) : (
         <FooterHoverCTALink

--- a/components/footer/FooterLink.tsx
+++ b/components/footer/FooterLink.tsx
@@ -21,7 +21,7 @@ export default function FooterLink({
   return (
     <Link
       href={`/${locale}/${link}`}
-      className={`md:border-0 border-foreground ${isActive ? 'md:underline' : ''} w-[50%] md:w-[15%] flex items-center sm:justify-center px-6 text-xl font-bold hover:bg-primary hover:text-primary-foreground hover:underline ${className}`}
+      className={`md:border-0 border-foreground ${isActive ? 'underline' : ''} w-[50%] md:w-[15%] flex items-center sm:justify-center px-10 md:px-6 text-xl md:font-bold hover:bg-primary hover:text-primary-foreground hover:underline ${className}`}
       aria-label={t(allyTranslationKey)}
     >
       {t(translationKey)}

--- a/components/footer/MobileFooterExtension.tsx
+++ b/components/footer/MobileFooterExtension.tsx
@@ -62,7 +62,7 @@ export default function MobileFooterExtension({
             href="#ticket-block"
             className="hover:underline fixed bottom-footer-height h-footer-height border-t w-full bg-background-event md:hidden flex justify-center items-center"
           >
-            <span className="uppercase font-bold">{t_event('buy-ticket')}</span>
+            <span className="font-bold uppercase text-xl">{t_event('buy-ticket')}</span>
           </Link>
         )
       ) : (


### PR DESCRIPTION
## Hva er gjort?

- Større mellomrom mellom “Meny” og “Program” i footer på telefon. Bold font på desktop, ikke bold på mobil.
- "Kjøp billett" over footer på mobil større skriftstørrelse